### PR TITLE
Fix: Golang CI Config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/loopholelabs/frpc-go
+    local-prefixes: github.com/loopholelabs/scale-signature-interfaces
   govet:
     # enable or disable analyzers by name
     disable:


### PR DESCRIPTION
This PR fixes the Golang CI Config file so it uses the proper package prefix